### PR TITLE
remove deploy on pull request to the main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: website-frontend CI
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 permissions:
   contents: write


### PR DESCRIPTION
#### Reference Issues/PRs

#### What does this implement/fix? Explain your changes.
Previously, We had deployment on the main domain based on a pull request to the main branch feature in the `build.yml`.
The issue with this feature is that, since this repository is public, you can easily send a pull request from any branch of any of your own repositories to this branch, or you can fork it and add anything (maybe harmful) and send a pull request from yours to the main branch, with ability to deploy, it may lead to deployment of the random (may malicious and harmful) website on our domain.

We will soon add deployment on the dev domain and also restrict action execution from pull requests from foreign repositories.
#### Any other comments?

